### PR TITLE
feat: `helm tiller run`

### DIFF
--- a/scripts/tiller.sh
+++ b/scripts/tiller.sh
@@ -12,41 +12,73 @@ function usage() {
   Usage:
     helm tiller start [tiller_namespace]
     helm tiller stop
+    helm tiller run [tiller_namespace] -- [command] [args]
 
   Available Commands:
     start   Start Tiller
+    run     Start Tiller and run arbitrary command within the environment
     stop    Stop Tiller
 
   Example use with the set namespace:
 
     $ helm tiller start my_tiller_namespace
 
+  Example use of `run`, that starts/stops tiller before/after the specified command:
+
+    $ helm tiller run helm list
+    $ helm tiller run mytiller-system -- helm list
+    $ helm tiller run mytiller-system -- bash -c 'echo running helm; helm list'
+
   EOF
+}
+
+helm_env() {
+  if [[ -n "$1" ]]
+  then
+    # Set namespace
+    echo export TILLER_NAMESPACE=${1}
+  fi
+  echo export HELM_HOST=localhost:44134
+}
+
+start_tiller() {
+  ./bin/tiller --storage=secret & helm version
+  echo "Tiller namespace: $TILLER_NAMESPACE "
+}
+
+stop_tiller() {
+  pwd
+  echo "Stopping Tiller..."
+  pkill -f ./bin/tiller
 }
 
 COMMAND=$1
 
+shift
+
 case $COMMAND in
 start)
-  if [[ -n "$2" ]]
-  then
-    # Set namespace
-    export TILLER_NAMESPACE=${2}
-    export HELM_HOST=localhost:44134
-    ./bin/tiller --storage=secret & helm version
-    echo "Tiller namespace: $TILLER_NAMESPACE "
-    /bin/bash
-  else
-    export HELM_HOST=localhost:44134
-    ./bin/tiller --storage=secret & helm version
-    echo "Tiller namespace: kube-system "
-    /bin/bash
-  fi
+  eval $(helm_env "$@")
+  start_tiller
+  bash
+  ;;
+run)
+  start_args=()
+  args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -- ) start_args=( "${args[@]}" ); args=(); shift ;;
+      * ) args+=("${1}"); shift ;;
+    esac
+  done
+  trap stop_tiller EXIT
+  echo args="${args[@]}"
+  eval $(helm_env "${start_args[@]}")
+  start_tiller "${start_args[@]}"
+  "${args[@]}"
   ;;
 stop)
-  pwd
-  echo "Stopping Tiller..."
-  pkill -f tiller
+  stop_tiller
   ;;
 *)
   usage


### PR DESCRIPTION
Adds `helm tiller run` to run arbitrary command with start/stopping tiller before/after that.

`helm tiller start` is awesome for interactive, human usage. But to me, it seems to lack scriptability for CI/CD usage.

More concretely, I'd want to script things like:

```bash
helm tiller start
helm upgrade --install myrelease mychart
helm tiller stop
```

so that I can run tiller only when it is actually required.

However, `helm-tiller` as of today doesn't seem to support this, due to the script is stopped at the point `helm-tiller` starts a `bash` with the envvars for tiller connectivity.

With `helm tiller run`, you can basically run any bash command within the environment created by `helm tiller start`.

See the output from `helm tiller help`(`help` can actually be anything :wink:) for usage examples. My favorite one is `helm tiller run mytiller-system -- bash -c 'your bash script'`, which has limitless possibility!