### PR TITLE
fix: install.sh breaks on helm v2.11.0 or greater for non-bash4 env like macOS

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "tiller"
-version: "0.6.3"
+version: "0.6.4"
 usage: "Please see https://github.com/rimusz/helm-tiller for usage"
 description: "Start a Tiller server locally, aka Tillerless Helm"
 command: "$HELM_PLUGIN_DIR/scripts/tiller.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,12 +21,14 @@ ARCH=$(uname -m)
 # shellcheck disable=SC2086
 COMPARE_VERSION=$(./scripts/semver compare $VERSION 2.11.0)
 
+os="$(echo "${OS}" | tr '[A-Z]' '[a-z]')"
+
 if [[ ${COMPARE_VERSION} -ge 0 ]]; then
   # Helm v2.11 and versions above
-  URL=https://storage.googleapis.com/kubernetes-helm/helm-v"${VERSION}"-"${OS}"-amd64.tar.gz
+  URL=https://storage.googleapis.com/kubernetes-helm/helm-v"${VERSION}"-"${os}"-amd64.tar.gz
 else
   # Helm v2.10 and versions below
-  URL=https://storage.googleapis.com/helm-tiller/tiller-v"${VERSION}"_"${OS}"_x86_64.tgz
+  URL=https://storage.googleapis.com/helm-tiller/tiller-v"${VERSION}"_"${os}"_x86_64.tgz
 fi
 
 if [ "$URL" = "" ]
@@ -52,7 +54,7 @@ fi
 # Install to bin
 if [[ ${COMPARE_VERSION} -ge 0 ]]; then
   # Helm v2.11 and versions above
-  rm -rf bin && mkdir bin && tar xvf "$FILENAME" -C bin --strip=1 "${OS,,}"-amd64/tiller > /dev/null && rm -f "$FILENAME"
+  rm -rf bin && mkdir bin && tar xvf "$FILENAME" -C bin --strip=1 "${os}"-amd64/tiller > /dev/null && rm -f "$FILENAME"
 else
   # Helm v2.10 and versions below
   rm -rf bin && mkdir bin && tar xzvf "$FILENAME" -C bin > /dev/null && rm -f "$FILENAME"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ COMPARE_VERSION=$(./scripts/semver compare $VERSION 2.11.0)
 
 if [[ ${COMPARE_VERSION} -ge 0 ]]; then
   # Helm v2.11 and versions above
-  URL=https://storage.googleapis.com/kubernetes-helm/helm-v"${VERSION}"-"${OS,,}"-amd64.tar.gz
+  URL=https://storage.googleapis.com/kubernetes-helm/helm-v"${VERSION}"-"${OS}"-amd64.tar.gz
 else
   # Helm v2.10 and versions below
   URL=https://storage.googleapis.com/helm-tiller/tiller-v"${VERSION}"_"${OS}"_x86_64.tgz


### PR DESCRIPTION
Hey!

This patch fixes the bad substitution error that breaks my helm-tiller.

```
$ helm tiller run -- helmfile diff
Installed Helm version v2.11.0
Copied found /usr/local/bin/tiller to helm-tiller/bin
Installing Tiller v2.11.0 ...
./scripts/install.sh: line 26: ${OS,,}: bad substitution
```