### PR TITLE
Updated to have flag for not creating namespace if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Available environment variables:
 - To store Tiller logs in `$HOME/.helm/plugins/helm-tiller/logs` by setting `HELM_TILLER_LOGS=true`.
 - You can set a specific folder/file for Tiller logs by setting `HELM_TILLER_LOGS_DIR=/some_folder/tiller.logs`.
 - To change default Tiller maximum number of releases kept in release history by setting e.g. to 20 `HELM_TILLER_HISTORY_MAX=20`.
+- To not automatically create a namespace if it is missing by setting `CREATE_NAMESPACE_IF_MISSING=false`.
 
 ### Tiller start examples
 

--- a/scripts/tiller.sh
+++ b/scripts/tiller.sh
@@ -8,6 +8,7 @@ set -o errexit
 : "${HELM_TILLER_LOGS:=false}"
 : "${HELM_TILLER_LOGS_DIR:=/dev/null}"
 : "${HELM_TILLER_HISTORY_MAX:=20}"
+: "${CREATE_NAMESPACE_IF_MISSING:=true}"
 
 CURRENT_FOLDER=$(pwd)
 
@@ -42,6 +43,7 @@ function usage() {
     'HELM_TILLER_LOGS=true' - store Tiller logs in '$HOME/.helm/plugins/helm-tiller/logs'.
     'HELM_TILLER_LOGS_DIR=/some_folder/tiller.logs' - set a specific folder/file for Tiller logs.
     'HELM_TILLER_HISTORY_MAX=20' - change maximum number of releases kept in release history by Tiller.
+    'CREATE_NAMESPACE_IF_MISSING=false' - indicate whether the namespace should be created if it does not exist.
 
   Example use with the set namespace:
     $ helm tiller start my-tiller-namespace
@@ -107,7 +109,9 @@ helm_env() {
     # Set namespace
     echo export TILLER_NAMESPACE="${1}"
     export TILLER_NAMESPACE="${1}"
-    create_ns $1
+    if [[ "${CREATE_NAMESPACE_IF_MISSING}" == "true" ]]; then
+      create_ns $1
+    fi
   fi
   echo export HELM_HOST=127.0.0.1:${HELM_TILLER_PORT}
   export HELM_HOST=127.0.0.1:${HELM_TILLER_PORT}


### PR DESCRIPTION
A recent change (merged about 4 hours ago) where the namespace is created if it does not exist has broken my usage of this plugin - specifically, the RBAC permissions that I am using when executing this script does not have the rights to get/create namespaces. Adding a flag that will disable creation of the namespace if it does not exist.