### PR TITLE
Add custom probe port

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Available environment variables:
 
 - To silence plugin specific messages by setting `HELM_TILLER_SILENT=true`, only `helm` cli output will be printed.
 - To change default Tiller port by setting `HELM_TILLER_PORT=44140`, default is `44134`.
+- To change default Tiller probe port by setting `HELM_TILLER_PROBE_PORT=44141`, default is `44135` - requires Helm >= 2.14.
 - To change Tiller storage to `configmap` by setting `HELM_TILLER_STORAGE=configmap`, default is `secret`.
 - To store Tiller logs in `$HOME/.helm/plugins/helm-tiller/logs` by setting `HELM_TILLER_LOGS=true`.
 - You can set a specific folder/file for Tiller logs by setting `HELM_TILLER_LOGS_DIR=/some_folder/tiller.logs`.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "tiller"
-version: "0.8.2"
+version: "0.8.3"
 usage: "Please see https://github.com/rimusz/helm-tiller for usage"
 description: "Start a Tiller server locally, aka Tillerless Helm"
 command: "$HELM_PLUGIN_DIR/scripts/tiller.sh"

--- a/scripts/tiller.sh
+++ b/scripts/tiller.sh
@@ -4,6 +4,7 @@ set -o errexit
 
 : "${HELM_TILLER_SILENT:=false}"
 : "${HELM_TILLER_PORT:=44134}"
+: "${HELM_TILLER_PROBE_PORT:=44135}"
 : "${HELM_TILLER_STORAGE:=secret}"
 : "${HELM_TILLER_LOGS:=false}"
 : "${HELM_TILLER_LOGS_DIR:=/dev/null}"
@@ -39,6 +40,7 @@ function usage() {
   Available environment variables:
     'HELM_TILLER_SILENT=true' - silence plugin specific messages, only `helm` cli output will be printed.
     'HELM_TILLER_PORT=44140' - change Tiller port, default is `44134`.
+    'HELM_TILLER_PROBE_PORT=44141' - change Tiller probe port, default is `44135`. Requires Helm >= 2.14.
     'HELM_TILLER_STORAGE=configmap' - change Tiller storage to `configmap`, default is `secret`.
     'HELM_TILLER_LOGS=true' - store Tiller logs in '$HOME/.helm/plugins/helm-tiller/logs'.
     'HELM_TILLER_LOGS_DIR=/some_folder/tiller.logs' - set a specific folder/file for Tiller logs.
@@ -155,7 +157,10 @@ tiller_env() {
 
 start_tiller() {
   tiller_env
-  { ./bin/tiller --storage=${HELM_TILLER_STORAGE} --listen=127.0.0.1:${HELM_TILLER_PORT} --history-max=${HELM_TILLER_HISTORY_MAX} & } 2>"${HELM_TILLER_LOGS_DIR}"
+  PROBE_LISTEN_FLAG="--probe-listen=127.0.0.1:${HELM_TILLER_PROBE_PORT}"
+  # check if we have a version that supports the --probe-listen flag
+  ./bin/tiller --help 2>&1 | grep probe-listen > /dev/null || PROBE_LISTEN_FLAG=""
+  { ./bin/tiller --storage=${HELM_TILLER_STORAGE} --listen=127.0.0.1:${HELM_TILLER_PORT} ${PROBE_LISTEN_FLAG} --history-max=${HELM_TILLER_HISTORY_MAX} & } 2>"${HELM_TILLER_LOGS_DIR}"
   if [[ "${HELM_TILLER_SILENT}" == "false" ]]; then
     echo "Tiller namespace: $TILLER_NAMESPACE"
   fi


### PR DESCRIPTION
Since Helm 2.14, there is a new cmdline flag to specify a custom probe port - defaults to 44135
This introduces a new environment variable HELM_TILLER_PROBE_PORT to set a custom probe port

Note that we check if the new flag is exposed before using it