### PR TITLE
Use the -9 kill signal with pkill

### DIFF
--- a/scripts/tiller.sh
+++ b/scripts/tiller.sh
@@ -175,7 +175,7 @@ stop_tiller() {
   if [[ "${HELM_TILLER_SILENT}" == "false" ]]; then
     echo "Stopping Tiller..."
   fi
-  pkill -f ./bin/tiller
+  pkill -9 -f ./bin/tiller
 }
 
 COMMAND=$1


### PR DESCRIPTION
When `helm tiller start-ci` is run in a golang/exec command, running `helm tiller stop` in the parent shell or a different golang/exec command does not stop the `./bin/tiller` process.

I ran into this when trying to start `helm tiller start-ci` in a terragrunt before hook and terragrunt uses golang/exec to run their commands.

In golang/exec (https://golang.org/pkg/os/exec/) it says this:

"Unlike the "system" library call from C and other languages, the os/exec package intentionally does not invoke the system shell ..."

Which is the likely cause of the issue.

To overcome this, all we need to do is to change `pkill -f ./bin/tiller` to `pkill -9 -f ./bin/tiller`. Sending `-9` means sending a stronger kill signal to the process, to ensure even non-responding process are killed.